### PR TITLE
Feature/Prep for Riva integration

### DIFF
--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -11,8 +11,10 @@ Pod::Spec.new do |s|
 	"Tez" => "tez.park@sendbird.com"
   	}
 	s.platform     = :ios, "11.0"
-	s.source = { :git => "https://github.com/sendbird/sendbird-uikit-ios.git", :tag => "v#{s.version}" }
-	s.ios.vendored_frameworks = 'Framework/SendbirdUIKit.xcframework'
+    s.source = { :git => "https://github.com/rivahealth/sendbird-uikit-ios.git", :tag => "v#{s.version}" }
+    s.ios.source_files = 'Sources/**/*.{swift}'
+    s.ios.resources = 'Sources/**/*.{xib}'
+    s.ios.resource_bundle = { 'SendbirdAssetBundle' => 'Sources/Resource/Assets.xcassets' }
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
 	s.dependency "SendbirdChatSDK", ">= 4.1.6"

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
 	"Tez" => "tez.park@sendbird.com"
   	}
 	s.platform     = :ios, "11.0"
-    s.source = { :git => "https://github.com/rivahealth/sendbird-uikit-ios.git", :tag => "v#{s.version}" }
-    s.ios.source_files = 'Sources/**/*.{swift}'
-    s.ios.resources = 'Sources/**/*.{xib}'
-    s.ios.resource_bundle = { 'SendbirdAssetBundle' => 'Sources/Resource/Assets.xcassets' }
+	s.source = { :git => "https://github.com/rivahealth/sendbird-uikit-ios.git", :tag => "v#{s.version}" }
+	s.ios.source_files = 'Sources/**/*.{swift}'
+	s.ios.resources = 'Sources/**/*.{xib}'
+	s.ios.resource_bundle = { 'SendbirdAssetBundle' => 'Sources/Resource/Assets.xcassets' }
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
 	s.dependency "SendbirdChatSDK", ">= 4.1.6"

--- a/Sources/Constant/SBUConstant.swift
+++ b/Sources/Constant/SBUConstant.swift
@@ -29,7 +29,12 @@ class SBUConstant {
     
     static let extensionKeyUIKit = "sb_uikit"
     
-    static let bundleIdentifier = "com.sendbird.uikit"
+    /// Represents the `resource_bundle` created by Cocoapods (declared in `SendBirdUIKit.podspec`).
+    static let sendbirdAssetBundle = Bundle(url: SBUConstant.currentBundle.url(forResource: "SendbirdAssetBundle", withExtension: "bundle")!)
+
+    static let currentBundle = Bundle(for: SBUConstant.self)
+    static var bundleIdentifier = SBUConstant.currentBundle.bundleIdentifier!
+    
     
     static let groupChannelDelegateIdentifier = "\(bundleIdentifier).delegate.channel.group"
     static let openChannelDelegateIdentifier = "\(bundleIdentifier).delegate.channel.open"

--- a/Sources/Enums/SBUIconSetType.swift
+++ b/Sources/Enums/SBUIconSetType.swift
@@ -91,8 +91,8 @@ public enum SBUIconSetType: String, Hashable {
     
     // MARK: - Image handling
     
-    private static let bundle = Bundle(identifier: SBUConstant.bundleIdentifier)
-    
+    private static let bundle = SBUConstant.sendbirdAssetBundle
+
     func load(tintColor: UIColor? = nil) -> UIImage {
         guard let image = UIImage(named: self.rawValue, in: SBUIconSetType.bundle, compatibleWith: nil) else {
             return UIImage()

--- a/Sources/Extension/UIImageView+SBUIKit.swift
+++ b/Sources/Extension/UIImageView+SBUIKit.swift
@@ -24,7 +24,7 @@ public extension UIImageView {
                    thumbnailSize: CGSize? = nil,
                    cacheKey: String? = nil,
                    completion: ((Bool) -> Void)? = nil) -> URLSessionTask? {
-        self.setImage(placeholder, contentMode: .center)
+        self.setImage(placeholder, contentMode: .scaleAspectFit)
         
         if urlString.isEmpty {
             if let errorImage = errorImage {

--- a/Sources/Extension/UIImageView+SBUIKit.swift
+++ b/Sources/Extension/UIImageView+SBUIKit.swift
@@ -22,9 +22,10 @@ public extension UIImageView {
                    errorImage: UIImage? = nil,
                    option: ImageOption = .original,
                    thumbnailSize: CGSize? = nil,
+                   contentMode: ContentMode = .center,
                    cacheKey: String? = nil,
                    completion: ((Bool) -> Void)? = nil) -> URLSessionTask? {
-        self.setImage(placeholder, contentMode: .scaleAspectFit)
+        self.setImage(placeholder, contentMode: contentMode)
         
         if urlString.isEmpty {
             if let errorImage = errorImage {

--- a/Sources/Theme/SBUTheme.swift
+++ b/Sources/Theme/SBUTheme.swift
@@ -1730,7 +1730,7 @@ public class SBUMessageCellTheme {
     
     // User
     public var userPlaceholderBackgroundColor: UIColor
-    public var userPlaceholderTintColor: UIColor
+    public var userPlaceholderTintColor: UIColor?
     public var userNameFont: UIFont
     public var userNameTextColor: UIColor
     public var currentUserNameTextColor: UIColor
@@ -2062,7 +2062,7 @@ public class SBUUserCellTheme {
     public var userIdTextColor: UIColor
     public var userIdTextFont: UIFont
     public var userPlaceholderBackgroundColor: UIColor
-    public var userPlaceholderTintColor: UIColor
+    public var userPlaceholderTintColor: UIColor?
     public var mutedStateBackgroundColor: UIColor
     public var mutedStateIconColor: UIColor
     public var subInfoTextColor: UIColor
@@ -2419,7 +2419,7 @@ public class SBUUserProfileTheme {
     public var overlayColor: UIColor
     public var backgroundColor: UIColor
     public var userPlaceholderBackgroundColor: UIColor
-    public var userPlaceholderTintColor: UIColor
+    public var userPlaceholderTintColor: UIColor?
     public var usernameTextColor: UIColor
     public var usernameFont: UIFont
     public var largeItemTintColor: UIColor
@@ -3004,7 +3004,7 @@ public class SBUComponentTheme {
     
     // placeholder
     public var userPlaceholderBackgroundColor: UIColor
-    public var userPlaceholderTintColor: UIColor
+    public var userPlaceholderTintColor: UIColor?
     
     public var placeholderBackgroundColor: UIColor
     public var placeholderTintColor: UIColor

--- a/Sources/View/Channel/CellView/SBUMessageProfileView.swift
+++ b/Sources/View/Channel/CellView/SBUMessageProfileView.swift
@@ -87,7 +87,8 @@ open class SBUMessageProfileView: SBUView {
             placeholder: SBUIconSetType.iconUser.image(
                 with: self.theme.userPlaceholderTintColor,
                 to: SBUIconSetType.Metric.iconUserProfileInChat
-            )
+            ),
+            contentMode: .scaleAspectFit
         )
         self.imageView.backgroundColor = theme.userPlaceholderBackgroundColor
     }


### PR DESCRIPTION
Preps the `riva` branch with changes necessary to support the UI in Riva Health:
- Update the podspec to avoid needing to compile an xcframework
- Declare a Cocoapods asset bundle for the `xcassets` and update any code to point to new bundle
- Update bundle identifier to dynamically grab it for the current class (since CocoaPods will generate a unique bundle ID)
- Make `userPlaceholderTintColor` to avoid Sendbird applying tint colors on our custom placeholder icons